### PR TITLE
[feat] Broke out build and copy methods into smaller ones.

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -2,26 +2,45 @@ import { writeFile, mkdir } from 'node:fs/promises';
 import { basename, dirname, join, resolve } from 'node:path';
 
 /**
+ * Write the file to the build directory while creating the directory, recursively, if it doesn't exist.
+ *
+ * @param {string} path
+ * @param {string} buildDir
+ * @param {string} contents
+ */
+export const writeFileAndMakeDir = async (path, buildDir, contents) => {
+  const filename = basename(path, '.mjs');
+
+  const directory =
+    filename === 'index'
+      ? join(buildDir, dirname(path))
+      : join(buildDir, dirname(path), filename);
+
+  await mkdir(directory, { recursive: true });
+
+  await writeFile(join(directory, 'index.html'), contents);
+};
+
+/**
+ * Import the default export of a JavaScript file and check that the default export is a string before writing the contents to a build file.
+ *
+ * @param {string} path
+ * @param {string} buildDir
+ */
+export const buildFile = async (path, buildDir) => {
+  const contents = (await import(resolve(path))).default;
+
+  if (typeof contents === 'string') {
+    await writeFileAndMakeDir(path, buildDir, contents);
+  }
+};
+
+/**
+ * Iterate over all the file paths and write them to the build directory.
+ *
  * @param {string[]} paths
  * @param {string} buildDir
  */
 export const buildFiles = async (paths, buildDir) => {
-  await Promise.all(
-    paths.map(async path => {
-      const filename = basename(path, '.mjs');
-
-      const directory =
-        filename === 'index'
-          ? join(buildDir, dirname(path))
-          : join(buildDir, dirname(path), filename);
-
-      const html = (await import(resolve(path))).default;
-
-      if (typeof html === 'string') {
-        await mkdir(directory, { recursive: true });
-
-        await writeFile(join(directory, `index.html`), html);
-      }
-    })
-  );
+  await Promise.all(paths.map(async path => await buildFile(path, buildDir)));
 };

--- a/src/copy.js
+++ b/src/copy.js
@@ -2,15 +2,25 @@ import { copyFile, mkdir } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 
 /**
+ * Copy the file to the build directory while creating the directory, recursively, if it doesn't exist.
+ *
+ * @param {string} path
+ * @param {string} buildDir
+ */
+export const copyFileAndMakeDir = async (path, buildDir) => {
+  await mkdir(join(buildDir, dirname(path)), { recursive: true });
+
+  await copyFile(path, join(buildDir, path));
+};
+
+/**
+ * Iterate over all the file paths and copy them to the build directory.
+ *
  * @param {string[]} paths
  * @param {string} buildDir
  */
 export const copyFiles = async (paths, buildDir) => {
   await Promise.all(
-    paths.map(async path => {
-      await mkdir(join(buildDir, dirname(path)), { recursive: true });
-
-      await copyFile(path, join(buildDir, path));
-    })
+    paths.map(async path => await copyFileAndMakeDir(path, buildDir))
   );
 };

--- a/src/html.js
+++ b/src/html.js
@@ -1,4 +1,6 @@
 /**
+ * String template utility that adds syntax highlighting and formatting in text editors.
+ *
  * @param {TemplateStringsArray} strings
  * @param {any[]} values
  */

--- a/src/html.test.js
+++ b/src/html.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 
 import { html } from './html.js';
 
-describe('html string template', async () => {
+describe('html string template utility', async () => {
   test('simple html string', () => {
     assert.equal(
       html`<span><b>this is a test</b></span>`,


### PR DESCRIPTION
Improved JSDoc header comments.

Broke out the `buildFile` and `copyFiles` methods into smaller methods to allow easier reuse for internal and external uses.

## Pull Request Type

- [ ] Bugfix
- [x] Enhancement
- [ ] Documentation
- [ ] Other (please describe):

## Relevant Issues

n/a

## What was the behavior before this feature/fix?

The build and copy methods were single, multi-feature methods.

## What is the behavior after this feature/fix?

The build and copy methods have been broken into smaller methods based on functionality.

## Benchmark Results

No change.

## Other Information
