### PR TITLE
[feat] Added input arg and version, help and out flags.

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -34,8 +34,8 @@ if (args.flags['--version'] || args.flags['-v']) {
 
    -h, --help            Display this help message.
    -v, --version         Display the current installed version.
-   -o, --out             Sets build directory.
-   -i, --ignore          Sets ignore file path.
+   -o, --out             Sets build directory. Default path is build/
+   -i, --ignore          Sets ignore file path. Default path is .onlyignore
 `);
   process.exit();
 }

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,16 +1,60 @@
 #!/usr/bin/env node
 
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { globby } from 'globby';
+
+import parseCmdArgs from 'parse-cmd-args';
 
 import { buildFiles } from '../src/build.js';
 import { copyFiles } from '../src/copy.js';
 
+const args = parseCmdArgs(null, {
+  requireUserInput: false
+});
+
+if (args.flags['--version'] || args.flags['-v']) {
+  process.stdout.write(
+    `${
+      JSON.parse(
+        await readFile(
+          join(dirname(fileURLToPath(import.meta.url)), '../package.json'),
+          'utf8'
+        )
+      ).version
+    }\n`
+  );
+  process.exit();
+} else if (args.flags['--help'] || args.flags['-h']) {
+  process.stdout.write(`Usage: onlybuild <path> ... [options]
+
+  Options:
+
+   -h, --help            Display this help message.
+   -v, --version         Display the current installed version.
+   -o, --out             Sets build directory.
+   -i, --ignore          Sets ignore file path.
+`);
+  process.exit();
+}
+
+const [buildDir = 'build/'] = [args.flags['--out'], args.flags['-o']]
+  .filter(flag => typeof flag === 'string')
+  .map(String);
+
+const [ignoreFile = '.onlyignore'] = [args.flags['--ignore'], args.flags['-i']]
+  .filter(flag => typeof flag === 'string')
+  .map(String);
+
 await buildFiles(
-  await globby(['**/*.mjs', '!_*/**/*', '!node_modules/', '!build/'], {
+  await globby(['**/*.mjs', '!_*/**/*', '!node_modules/', `!${buildDir}`], {
     gitignore: true,
-    ignoreFiles: ['.onlyignore']
+    ignoreFiles: [ignoreFile],
+    cwd: args.inputs[0]
   }),
-  'build/'
+  buildDir
 );
 
 await copyFiles(
@@ -22,14 +66,15 @@ await copyFiles(
       '!package.json',
       '!package-lock.json',
       '!node_modules/',
-      '!build/'
+      `!${buildDir}`
     ],
     {
       gitignore: true,
-      ignoreFiles: ['.onlyignore']
+      ignoreFiles: [ignoreFile],
+      cwd: args.inputs[0]
     }
   ),
-  'build/'
+  buildDir
 );
 
 export {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "globby": "14.0.1"
+        "globby": "14.0.1",
+        "parse-cmd-args": "5.0.1"
       },
       "bin": {
         "onlybuild": "bin/index.js"
@@ -189,6 +190,14 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/parse-cmd-args": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cmd-args/-/parse-cmd-args-5.0.1.tgz",
+      "integrity": "sha512-ofiV/L27jO5xv+huOeMdzO3fJPd+TRLGzJ9/B8/W6PNiMNvzlIe6f6rhdFuRaP9YPWUj5DgsDsFXAkP0KNUWXQ==",
+      "engines": {
+        "node": ">=20.x"
       }
     },
     "node_modules/path-type": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "main": "./src/index.js",
   "license": "MIT",
   "dependencies": {
-    "globby": "14.0.1"
+    "globby": "14.0.1",
+    "parse-cmd-args": "5.0.1"
   },
   "scripts": {
     "test": "node --test"


### PR DESCRIPTION
This adds CLI input and flags to `onlybuild`. Now you can choose where the source files are located, the build directory, 

## Pull Request Type

- [ ] Bugfix
- [x] Enhancement
- [ ] Documentation
- [ ] Other (please describe):

## Relevant Issues

n/a

## What was the behavior before this feature/fix?

You couldn't change anything with how `onlybuild` runs.

## What is the behavior after this feature/fix?

1. The user can change where the source files are located.  Default is the current directory.
2. The user can change where the build files are created. Default is `build/`.
3. The user can change the path of the ignore file. Default is `.onlyignore`.
4. The user can show the version of `onlybuild`
5. The user can how the CLI help message.

## Benchmark Results

No change.

## Other Information
