### PR TITLE
[hotfix] Disable gitignore in globby.

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -50,7 +50,7 @@ const [ignoreFile = '.onlyignore'] = [args.flags['--ignore'], args.flags['-i']]
 
 await buildFiles(
   await globby(['**/*.mjs', '!_*/**/*', '!node_modules/', `!${buildDir}`], {
-    gitignore: true,
+    gitignore: false,
     ignoreFiles: [ignoreFile],
     cwd: args.inputs[0]
   }),
@@ -69,7 +69,7 @@ await copyFiles(
       `!${buildDir}`
     ],
     {
-      gitignore: true,
+      gitignore: false,
       ignoreFiles: [ignoreFile],
       cwd: args.inputs[0]
     }

--- a/tests/benchmarks/.gitignore
+++ b/tests/benchmarks/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 
 build/
+
+posts/


### PR DESCRIPTION
Disabling the `.gitignore` flag in globbby file pattern match.

## Pull Request Type

- [x] Bugfix
- [ ] Enhancement
- [ ] Documentation
- [ ] Other (please describe):

## Relevant Issues

n/a

## What was the behavior before this feature/fix?

File patterns in `.gitignore` were getting ignored from build.

```
Lowest/fastest time to compile 250 markdown files: 0.300s
Lowest/fastest time to compile 500 markdown files: 0.371s
Lowest/fastest time to compile 1000 markdown files: 0.543s
Lowest/fastest time to compile 2000 markdown files: 0.824s
Lowest/fastest time to compile 4000 markdown files: 1.467s
```

## What is the behavior after this feature/fix?

The `.gitignore` could be ignoring dynamically created files that the user might want include in the build.

Also, slight improvement to build speed.

```
Lowest/fastest time to compile 250 markdown files: 0.296s
Lowest/fastest time to compile 500 markdown files: 0.356s
Lowest/fastest time to compile 1000 markdown files: 0.512s
Lowest/fastest time to compile 2000 markdown files: 0.770s
Lowest/fastest time to compile 4000 markdown files: 1.309s
```

## Benchmark Results

```
Lowest/fastest time to compile 250 markdown files: 0.296s
Lowest/fastest time to compile 500 markdown files: 0.356s
Lowest/fastest time to compile 1000 markdown files: 0.512s
Lowest/fastest time to compile 2000 markdown files: 0.770s
Lowest/fastest time to compile 4000 markdown files: 1.309s
```

## Other Information
