### PR TITLE
[hotfix] Fix permissions on bin file after build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "test": "node --import tsx --test ./src/*.test.ts",
-    "build": "rm -rf dist/ && tsc"
+    "build": "rm -rf dist/ && tsc && chmod +x ./dist/bin/index.js"
   },
   "keywords": [
     "javascript",


### PR DESCRIPTION
This fixes an issue where the built CLI command doesn't have the correct permissions to be run via the terminal.

## Pull Request Type

- [x] Bugfix
- [ ] Enhancement
- [ ] Documentation
- [ ] Other (please describe):

## Relevant Issues

n/a

## What was the behavior before this feature/fix?

Running `npm run build` from a project would result in this error:

```
npm run build

> build
> onlybuild

sh: .bin/onlybuild: Permission denied
```

## What is the behavior after this feature/fix?

The command works.

## Benchmark Results

n/a

## Other Information
