### PR TITLE
[hotfix] Added a prepare build target.

### DIFF
--- a/.github/workflows/publish.workflow.yml
+++ b/.github/workflows/publish.workflow.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build package
-        run: npm run build
-
       - name: NPM whoami
         run: npm whoami
         env:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "scripts": {
     "test": "node --import tsx --test ./src/*.test.ts",
-    "build": "rm -rf dist/ && tsc && chmod +x ./dist/bin/index.js"
+    "build": "rm -rf dist/ && tsc && chmod +x ./dist/bin/index.js",
+    "prepare": "npm run build"
   },
   "keywords": [
     "javascript",


### PR DESCRIPTION
Added a build step when `npm install` is run locally. This is a hotfix to prevent issues when running benchmarking tests when the package has not been built. It will also build before the package is published.

## Pull Request Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] Documentation
- [x] Other (please describe):

## Relevant Issues

n/a

## What was the behavior before this feature/fix?

Running `npm install` would just install dependencies but not build the project. 

## What is the behavior after this feature/fix?

Running `npm install` will install dependencies and build the project. `prepare` was chosen as the target as it only runs locally, unlike `postinstall` which runs when you install it as a dependency.

## Benchmark Results

n/a

## Other Information
