### PR TITLE
[feat] Added .env support.

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -4,6 +4,8 @@ import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import 'dotenv/config';
+
 import { globby } from 'globby';
 
 import parseCmdArgs from 'parse-cmd-args';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
+        "dotenv": "16.4.5",
         "globby": "14.0.1",
         "parse-cmd-args": "5.0.2"
       },
@@ -453,6 +454,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/esbuild": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/src/index.d.ts",
   "license": "MIT",
   "dependencies": {
+    "dotenv": "16.4.5",
     "globby": "14.0.1",
     "parse-cmd-args": "5.0.2"
   },


### PR DESCRIPTION
This adds `.env` support to all files run using `onlybuild`.

## Pull Request Type

- [ ] Bugfix
- [x] Enhancement
- [ ] Documentation
- [ ] Other (please describe):

## Relevant Issues

<https://github.com/neogeek/onlybuild/issues/5>

## What was the behavior before this feature/fix?

You would have to specify env variables in the CLI like this:

```bash
$ NODE_ENV=development npm run build
```

## What is the behavior after this feature/fix?

You can add env variables to a `.env` file and they will load automatically into all files run using `onlybuild`.

## Benchmark Results

n/a

## Other Information
