### PR TITLE
[hotfix] Fixed issue with getting version from package.json

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -1,8 +1,4 @@
-#!/usr/bin/env node
-
-import { readFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+#!/usr/bin/env node --no-warnings
 
 import 'dotenv/config';
 
@@ -13,21 +9,14 @@ import parseCmdArgs from 'parse-cmd-args';
 import { buildFiles } from '../src/build.js';
 import { copyFiles } from '../src/copy.js';
 
+import pkg from '../package.json' assert { type: 'json' };
+
 const args = parseCmdArgs(null, {
   requireUserInput: false
 });
 
 if (args.flags['--version'] || args.flags['-v']) {
-  process.stdout.write(
-    `${
-      JSON.parse(
-        await readFile(
-          join(dirname(fileURLToPath(import.meta.url)), '../package.json'),
-          'utf8'
-        )
-      ).version
-    }\n`
-  );
+  process.stdout.write(`${pkg.version}\n`);
   process.exit();
 } else if (args.flags['--help'] || args.flags['-h']) {
   process.stdout.write(`Usage: onlybuild <path> [options]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "esModuleInterop": true,
     "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
     "declaration": true,
     "outDir": "./dist",
     "strict": true


### PR DESCRIPTION
`--version` failed when called after the TypeScript migration.

## Pull Request Type

- [x] Bugfix
- [ ] Enhancement
- [ ] Documentation
- [ ] Other (please describe):

## Relevant Issues

n/a

## What was the behavior before this feature/fix?

`--version` failed.

## What is the behavior after this feature/fix?

`--version` works as expected.

## Benchmark Results

n/a

## Other Information
