### PR TITLE
[feat] Split build and copy logic into separate methods.

### DIFF
--- a/src/build.test.ts
+++ b/src/build.test.ts
@@ -1,0 +1,45 @@
+import test, { describe } from 'node:test';
+import assert from 'node:assert';
+
+import { buildFile, calculateOutputPathFromInputPath } from './build.js';
+
+describe('build files', async () => {
+  test('calculate output path from input path', () => {
+    assert.equal(calculateOutputPathFromInputPath('index.html'), 'index.html');
+    assert.equal(
+      calculateOutputPathFromInputPath('this-is-a-test.html'),
+      'this-is-a-test/index.html'
+    );
+    assert.equal(
+      calculateOutputPathFromInputPath('this-is-another-test/index.html'),
+      'this-is-another-test/index.html'
+    );
+  });
+  test('build file that returns a string', async () => {
+    assert.deepEqual(
+      await buildFile('./tests/mocks/export-returns-string.mjs'),
+      {
+        path: './tests/mocks/export-returns-string.mjs',
+        contents: '<h1>Hello, string!</h1>'
+      }
+    );
+  });
+  test('build file that returns a function', async () => {
+    assert.deepEqual(
+      await buildFile('./tests/mocks/export-returns-function.mjs'),
+      {
+        path: './tests/mocks/export-returns-function.mjs',
+        contents: ''
+      }
+    );
+  });
+  test("build file that doesn't return anything", async () => {
+    assert.deepEqual(
+      await buildFile('./tests/mocks/export-returns-nothing.mjs'),
+      {
+        path: './tests/mocks/export-returns-nothing.mjs',
+        contents: ''
+      }
+    );
+  });
+});

--- a/src/copy.ts
+++ b/src/copy.ts
@@ -2,25 +2,27 @@ import { copyFile, mkdir } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 
 /**
- * Copy the file to the build directory while creating the directory, recursively, if it doesn't exist.
+ * Copies a file from one path to another, creating parent directories as needed.
  *
- * @param {string} path
- * @param {string} buildDir
+ * @param {string} src
+ * @param {string} dest
  */
-export const copyFileAndMakeDir = async (path: string, buildDir: string) => {
-  await mkdir(join(buildDir, dirname(path)), { recursive: true });
+export const copyFileAndMakeDir = async (src: string, dest: string) => {
+  await mkdir(dirname(dest), { recursive: true });
 
-  await copyFile(path, join(buildDir, path));
+  await copyFile(src, dest);
 };
 
 /**
- * Iterate over all the file paths and copy them to the build directory.
+ * Iterate over all file paths and copy them to the build directory.
  *
  * @param {string[]} paths
  * @param {string} buildDir
  */
 export const copyFiles = async (paths: string[], buildDir: string) => {
   await Promise.all(
-    paths.map(async path => await copyFileAndMakeDir(path, buildDir))
+    paths.map(
+      async path => await copyFileAndMakeDir(path, join(buildDir, path))
+    )
   );
 };

--- a/tests/mocks/export-returns-function.mjs
+++ b/tests/mocks/export-returns-function.mjs
@@ -1,0 +1,3 @@
+/* node:coverage disable */
+
+export default () => '<h1>Hello, function!</h1>';

--- a/tests/mocks/export-returns-nothing.mjs
+++ b/tests/mocks/export-returns-nothing.mjs
@@ -1,0 +1,3 @@
+/* node:coverage disable */
+
+export {};

--- a/tests/mocks/export-returns-string.mjs
+++ b/tests/mocks/export-returns-string.mjs
@@ -1,0 +1,3 @@
+/* node:coverage disable */
+
+export default '<h1>Hello, string!</h1>';


### PR DESCRIPTION
This feature focuses on separating logic into more testable methods. This also improved the ability to import and use build and copy methods in your own projects.

## Pull Request Type

- [ ] Bugfix
- [x] Enhancement
- [ ] Documentation
- [ ] Other (please describe):

## Relevant Issues

n/a

## What was the behavior before this feature/fix?

Most of the utility methods performed more than one task, like calculating what the output file path and then writing that file.

## What is the behavior after this feature/fix?

Now methods focus on one task. For example, one method for calculating the output file path and another for writing that file.

## Benchmark Results

n/a

## Other Information
