### PR TITLE
[hotfix] Added experimental code coverage flag to test command.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "typescript": "5.4.5"
   },
   "scripts": {
-    "test": "node --import tsx --test ./src/*.test.ts",
+    "test": "node --import tsx --test --experimental-test-coverage ./src/*.test.ts",
     "build": "rm -rf dist/ && tsc && chmod +x ./dist/bin/index.js",
     "prepare": "npm run build"
   },


### PR DESCRIPTION
Added [`--experimental-test-coverage`](https://nodejs.org/api/cli.html#--experimental-test-coverage) flag to the `npm test` command.

## Pull Request Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] Documentation
- [x] Other (please describe): A hotfix that isn't a bug fix, nor adds additional functionality to the end user.

## Relevant Issues

n/a

## What was the behavior before this feature/fix?

Tests were run without code coverage.

## What is the behavior after this feature/fix?

Tests run with code coverage. Example:

```
ℹ ------------------------------------------------------------------------------------------
ℹ file                                    | line % | branch % | funcs % | uncovered lines
ℹ ------------------------------------------------------------------------------------------
ℹ src/build.test.ts                       | 100.00 |   100.00 |  100.00 |
ℹ src/build.ts                            |  86.84 |    90.91 |   57.14 | 28-32 34-35 40-42
ℹ src/html.test.ts                        | 100.00 |   100.00 |  100.00 |
ℹ src/html.ts                             | 100.00 |   100.00 |  100.00 |
ℹ tests/mocks/export-returns-function.mjs | 100.00 |   100.00 |  100.00 |
ℹ tests/mocks/export-returns-nothing.mjs  | 100.00 |   100.00 |  100.00 |
ℹ tests/mocks/export-returns-string.mjs   | 100.00 |   100.00 |  100.00 |
ℹ ------------------------------------------------------------------------------------------
ℹ all files                               |  94.29 |    97.14 |   86.96 |
ℹ ------------------------------------------------------------------------------------------
```

## Benchmark Results

n/a

## Other Information
