### PR TITLE
[hotfix] Fixed TypeScript logic to not override JavaScript functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ LICENSE
 > [!WARNING]
 > This feature is experimental.
 
-By default `onlybuild` looks for `.mjs` files, but if you add the `--typescript` flag to the build command, it will instead look for `.ts` files.
+By default `onlybuild` looks for `.mjs` files, but if you add the `--typescript` flag to the build command, it will also look for `.ts` files.
 
 ```bash
 $ npx onlybuild --typescript

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -52,11 +52,12 @@ if (typescript) {
 
 const filesToBuild = await globby(
   [
-    typescript ? '**/*.ts' : '**/*.mjs',
+    '**/*.mjs',
+    typescript ? '**/*.ts' : '',
     '!_*/**/*',
     '!node_modules/',
     `!${buildDir}`
-  ],
+  ].filter(Boolean),
   {
     gitignore: false,
     ignoreFiles: [ignoreFile],
@@ -67,7 +68,8 @@ const filesToBuild = await globby(
 const filesToCopy = await globby(
   [
     '**/*',
-    typescript ? '!**/*.ts' : '!**/*.mjs',
+    '!**/*.mjs',
+    '!**/*.ts',
     '!_*/**/*',
     '!package.json',
     '!package-lock.json',


### PR DESCRIPTION
Fixed an issue with TypeScript logic that prevents `.mjs` files from working as usual.

## Pull Request Type

- [x] Bugfix
- [ ] Enhancement
- [ ] Chore
- [ ] Documentation
- [ ] Other (please describe):

## Relevant Issues

n/a

## What was the behavior before this feature/fix?

If you added the `--typescript` flag it would switch to looking for `.ts` files only.

## What is the behavior after this feature/fix?

Now if you add the `--typescript` flag it will look for `.ts` files and `.mjs` files.

## Benchmark Results

n/a

## Other Information
