### PR TITLE
[hotfix] Added missing flag to pass options in shebang line.

### DIFF
--- a/.github/workflows/test.workflow.yml
+++ b/.github/workflows/test.workflow.yml
@@ -46,3 +46,7 @@ jobs:
       - name: Run tests
         timeout-minutes: 5
         run: npm test
+
+      - name: Test CLI
+        timeout-minutes: 5
+        run: ./dist/bin/index.js --version

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-warnings
+#!/usr/bin/env -S node --no-warnings
 
 import 'dotenv/config';
 


### PR DESCRIPTION
Added test.

Fixed bug where running `onlybuild` in GitHub Actions would cause this error:

```
/usr/bin/env: ‘node --no-warnings’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
```

## Pull Request Type

- [x] Bugfix
- [ ] Enhancement
- [ ] Chore
- [ ] Documentation
- [ ] Other (please describe):

## Relevant Issues

n/a

## What was the behavior before this feature/fix?

`onlybuild` would run locally fine, but in a GitHub Action workflow it was broken.

## What is the behavior after this feature/fix?

It now works in GitHub Action workflows, and a test was added to ensure its continued operation.

## Benchmark Results

n/a

## Other Information
