### PR TITLE
[feat] Removed dotenv package.

### DIFF
--- a/.github/workflows/publish.workflow.yml
+++ b/.github/workflows/publish.workflow.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.22
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update NPM to latest

--- a/.github/workflows/test.workflow.yml
+++ b/.github/workflows/test.workflow.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.22
 
       - name: Update NPM to latest
         run: npm install npm@latest -g

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -1,7 +1,5 @@
 #!/usr/bin/env -S node --no-warnings
 
-import 'dotenv/config';
-
 import 'tsx/esm';
 
 import { globby } from 'globby';
@@ -9,6 +7,8 @@ import { globby } from 'globby';
 import chalk from 'chalk';
 
 import parseCmdArgs from 'parse-cmd-args';
+
+import '../src/env.js';
 
 import { buildFiles, writeFiles } from '../src/build.js';
 import { copyFiles } from '../src/copy.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "typescript": "5.9.3"
       },
       "engines": {
-        "node": ">=20.x"
+        "node": ">=22.22"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
-        "dotenv": "17.3.1",
         "globby": "16.1.1",
         "parse-cmd-args": "5.0.2",
         "tsx": "4.21.0"
@@ -521,18 +520,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/esbuild": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "5.6.2",
-    "dotenv": "17.3.1",
     "globby": "16.1.1",
     "parse-cmd-args": "5.0.2",
     "tsx": "4.21.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A zero-config cli for building static websites.",
   "version": "1.6.6",
   "engines": {
-    "node": ">=20.x"
+    "node": ">=22.22"
   },
   "type": "module",
   "bin": {

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,6 @@
+import process from 'node:process';
+import { existsSync } from 'node:fs';
+
+if (existsSync('.env')) {
+  process.loadEnvFile('.env');
+}


### PR DESCRIPTION
Removed the dotenv package and used native node.js `process.loadEnvFile`.

## Pull Request Type

- [ ] Bugfix
- [ ] Enhancement
- [x] Chore
- [ ] Documentation
- [ ] Other (please describe):

## Relevant Issues

n/a

## What was the behavior before this feature/fix?

Removed reliance on third-party packages.

## What is the behavior after this feature/fix?

The min node.js version required to use this package is node.js 22.22.

## Benchmark Results

n/a

## Other Information
