### PR TITLE
[feat] Removed parse-cmd-args package.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
-        "parse-cmd-args": "5.0.2",
         "tsx": "4.21.0"
       },
       "bin": {
@@ -527,15 +526,6 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
-    "node_modules/parse-cmd-args": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/parse-cmd-args/-/parse-cmd-args-5.0.2.tgz",
-      "integrity": "sha512-boIo6nAaJJ/zO/cR0jKyYziZOgkFnDW3RVioESn12Y6RZe6cOE/UE7jPT38T2QFaHGBQjH+liszMoaAi4fmHSg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.x"
       }
     },
     "node_modules/resolve-pkg-maps": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "5.6.2",
-    "parse-cmd-args": "5.0.2",
     "tsx": "4.21.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Removed the parse-cmd-args package and used native node.js `parseArgs`.

## Pull Request Type

- [ ] Bugfix
- [ ] Enhancement
- [x] Chore
- [ ] Documentation
- [ ] Other (please describe):

## Relevant Issues

n/a

## What was the behavior before this feature/fix?

Removed reliance on third-party packages.

## What is the behavior after this feature/fix?

The min node.js version required to use this package is node.js 22.22.

## Benchmark Results

n/a

## Other Information
