### PR TITLE
[hotfix] Fixed issue with ignorefile not working.

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -2,7 +2,8 @@
 
 import 'tsx/esm';
 
-import { glob } from 'node:fs/promises';
+import { glob, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import { parseArgs } from 'node:util';
 
 import chalk from 'chalk';
@@ -51,6 +52,10 @@ const [ignoreFile = '.onlyignore'] = [args.values.ignore]
   .filter(Boolean)
   .map(String);
 
+const filesToIgnore = existsSync(ignoreFile)
+  ? (await readFile(ignoreFile, 'utf8')).split(/\n+/g).filter(Boolean)
+  : [];
+
 const filesToBuild = (
   await Array.fromAsync(
     glob(['**/*.mjs', '**/*.jsx', '**/*.ts', '**/*.tsx'].filter(Boolean), {
@@ -73,7 +78,8 @@ const filesToCopy = (
         'package-lock.json',
         'node_modules/',
         buildDir,
-        ignoreFile
+        ignoreFile,
+        ...filesToIgnore
       ],
       cwd: args.positionals[0]
     })


### PR DESCRIPTION
The ignore file worked differently in the previous version due to how a third-party glob library parsed the options. This requires a more manual approach.

## Pull Request Type

- [x] Bugfix
- [ ] Enhancement
- [ ] Chore
- [ ] Documentation
- [ ] Other (please describe):

## Relevant Issues

n/a

## What was the behavior before this feature/fix?

The ignore file was being ignored, not the file patterns in the file.

## What is the behavior after this feature/fix?

The file patterns in the ignore file are being ignored.

## Benchmark Results

n/a

## Other Information
